### PR TITLE
Issue #21: Skip call to function libxml_disable_entity_loader() on PHP8 since it is deprecated.

### DIFF
--- a/plugins/absolute_url.inc
+++ b/plugins/absolute_url.inc
@@ -39,13 +39,17 @@ function feeds_tamper_absolute_url_callback($result, $item_key, $element_key, &$
 
   // Supress warnings for invalid HTML.
   $errors = libxml_use_internal_errors(TRUE);
-  $entity_loader = libxml_disable_entity_loader(TRUE);
+  if (function_exists('libxml_disable_entity_loader') && PHP_VERSION_ID < 80000) {
+    $entity_loader = libxml_disable_entity_loader(TRUE);
+  }
 
   $dom->loadHTML($field);
 
   libxml_clear_errors();
   libxml_use_internal_errors($errors);
-  libxml_disable_entity_loader($entity_loader);
+  if (function_exists('libxml_disable_entity_loader') && PHP_VERSION_ID < 80000) {
+    libxml_disable_entity_loader($entity_loader);
+  }
 
   $urls = array();
   $tags = array('a' => 'href', 'img' => 'src', 'iframe' => 'src',


### PR DESCRIPTION
Fixes #21.
By @darko-hrgovic, @immaculate-srijan, @MegaChriz, @kiamlaluno.